### PR TITLE
fix(router): validate Link href at render time — throw instead of navigating to /undefined

### DIFF
--- a/packages/router/src/components.ts
+++ b/packages/router/src/components.ts
@@ -555,6 +555,13 @@ export function Link(config: LinkConfig): HTMLAnchorElement {
     throw new Error('Link requires a router in context. Make sure to use defineApp with a router.');
   }
 
+  if (href == null || href === '') {
+    throw new Error(
+      `LiteForge: <Link href> must be a non-empty string. Got: ${JSON.stringify(href)}. ` +
+      `If href comes from a signal or async source, ensure it is resolved before rendering Link.`
+    )
+  }
+
   // Create anchor element
   const anchor = document.createElement('a');
   anchor.href = href;

--- a/packages/router/tests/components.test.ts
+++ b/packages/router/tests/components.test.ts
@@ -548,6 +548,33 @@ describe('Link', () => {
     expect(() => Link({ href: '/about', children: 'About' })).toThrow('Link requires a router in context');
   });
 
+  describe('href validation', () => {
+    beforeEach(() => {
+      router = createTestRouter([{ path: '/', component: () => document.createElement('div') }]);
+      setupContext(router);
+    });
+
+    it('throws when href is undefined', () => {
+      expect(() => Link({ href: undefined as unknown as string, children: 'X' }))
+        .toThrow('LiteForge: <Link href> must be a non-empty string. Got: undefined')
+    })
+
+    it('throws when href is null', () => {
+      expect(() => Link({ href: null as unknown as string, children: 'X' }))
+        .toThrow('LiteForge: <Link href> must be a non-empty string. Got: null')
+    })
+
+    it('throws when href is empty string', () => {
+      expect(() => Link({ href: '', children: 'X' }))
+        .toThrow('LiteForge: <Link href> must be a non-empty string. Got: ""')
+    })
+
+    it('error message hints at reactive sources', () => {
+      expect(() => Link({ href: undefined as unknown as string, children: 'X' }))
+        .toThrow('signal or async source')
+    })
+  });
+
   describe('exact prop', () => {
     it('without exact: activeClass applied on prefix match', async () => {
       router = createTestRouter([


### PR DESCRIPTION
## Problem

`<Link href={undefinedValue}>` silently set `anchor.href = "undefined"`, navigated to `/undefined` on click. No error, no warning — hard to debug.

## Fix

Guard in `Link()` after the router context check, before `document.createElement('a')`:

```ts
if (href == null || href === '') {
  throw new Error(
    `LiteForge: <Link href> must be a non-empty string. Got: ${JSON.stringify(href)}. ` +
    `If href comes from a signal or async source, ensure it is resolved before rendering Link.`
  )
}
```

**Why after the router context check:** if there's no router, that error is more actionable. If there is a router but href is bad, this error fires with the exact value.

**Why Variante B (with reactive sources hint):** the most common cause is an unresolved signal or async data — the error message tells the user exactly where to look at 22:00.

**No fallback to `/` or `#`:** that would mask the bug. Fail fast, fail clearly.

## Tests

4 new tests in `describe('href validation')`:
- `undefined` → throws with `Got: undefined`
- `null` → throws with `Got: null`  
- `''` → throws with `Got: ""`
- error message contains `signal or async source`

All 464 router tests pass (was 460).

## Validation

- `pnpm vitest run packages/router/tests/` → 464/464 ✅
- `pnpm --filter @liteforge/router typecheck` → clean ✅

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)